### PR TITLE
Made conditions warning translatable

### DIFF
--- a/plugins/SegmentPlugin.php
+++ b/plugins/SegmentPlugin.php
@@ -380,7 +380,7 @@ class SegmentPlugin extends phplistPlugin
                     $combine
                 );
             } catch (SegmentPlugin_ValueException $e) {
-                $params['warning'] = 'one of the conditions has an invalid target value';
+                $params['warning'] = s('one of the conditions has an invalid target value');
             }
         }
 


### PR DESCRIPTION
This appears to be the only warning message to not use the ```s()``` translation function. This PR changes that.