### PR TITLE
New option to extend current segmentation by email address

### DIFF
--- a/plugins/SegmentPlugin/Operator.php
+++ b/plugins/SegmentPlugin/Operator.php
@@ -46,6 +46,7 @@ class SegmentPlugin_Operator
     const NOTCLICKED = 19;
     const BETWEEN = 20;
     const AFTERINTERVAL = 21;
+    const ISINCLUDED = 22;
 
     private function __construct()
     {


### PR DESCRIPTION
The option adds an additional way to segment the recipients of a newsletter by using a list of email addresses that can be copied and pasted inside a textarea (one per line) for example from a spreadsheet file. 

For the reasoning on why this could be useful take a look at issue #16 where this is discussed.