### PR TITLE
Extra segmentation criteria: Emails not included

### DIFF
--- a/plugins/SegmentPlugin/Operator.php
+++ b/plugins/SegmentPlugin/Operator.php
@@ -48,6 +48,7 @@ class SegmentPlugin_Operator
     const AFTERINTERVAL = 21;
     const ISINCLUDED = 22;
     const ANNIVERSARY = 23;
+    const ISNOTINCLUDED = 24;
 
     private function __construct()
     {

--- a/plugins/SegmentPlugin/SubscriberConditionEmail.php
+++ b/plugins/SegmentPlugin/SubscriberConditionEmail.php
@@ -69,6 +69,11 @@ class SegmentPlugin_SubscriberConditionEmail extends SegmentPlugin_Condition
                 $op = 'IN';
                 $target = '(' . $this->commaQuotedList($emails) . ')';
                 break;
+            case SegmentPlugin_Operator::ISNOTINCLUDED:
+                $emails = preg_split("/[\r\n]+/", $value, -1, PREG_SPLIT_NO_EMPTY);
+                $op = 'NOT IN';
+                $target = '(' . $this->commaQuotedList($emails) . ')';
+                break;
             case SegmentPlugin_Operator::IS:
             default:
                 $op = '=';

--- a/plugins/SegmentPlugin/SubscriberConditionEmail.php
+++ b/plugins/SegmentPlugin/SubscriberConditionEmail.php
@@ -40,7 +40,7 @@ class SegmentPlugin_SubscriberConditionEmail extends SegmentPlugin_Condition
 
     public function display($op, $value, $namePrefix)
     {
-        return $op == SegmentPlugin_Operator::ISINCLUDED
+        return $op == (SegmentPlugin_Operator::ISINCLUDED || SegmentPlugin_Operator::ISNOTINCLUDED)
             ? CHtml::textArea($namePrefix . '[value]', $value)
             : CHtml::textField($namePrefix . '[value]', $value);
     }

--- a/plugins/SegmentPlugin/SubscriberConditionEmail.php
+++ b/plugins/SegmentPlugin/SubscriberConditionEmail.php
@@ -34,6 +34,7 @@ class SegmentPlugin_SubscriberConditionEmail extends SegmentPlugin_Condition
             SegmentPlugin_Operator::REGEXP => s('REGEXP'),
             SegmentPlugin_Operator::NOTREGEXP => s('not REGEXP'),
             SegmentPlugin_Operator::ISINCLUDED => s('is included'),
+            SegmentPlugin_Operator::ISNOTINCLUDED => s('is not included')
         );
     }
 


### PR DESCRIPTION
Hello @bramley,

This is more or less the reverse of the 'is included' that was added some time ago. The reasoning for this type of segmentation is for example in a scenario where some clients might have been contacted through other means like sms, or a telephone call about some promotion, so when the time comes to send out the promotional campaign their emails must be excluded.